### PR TITLE
Updated expo sdk to v21

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "description": "No description",
     "slug": "react-native-expo-ocr-speed-read",
     "privacy": "public",
-    "sdkVersion": "20.0.0",
+    "sdkVersion": "21.0.0",
     "version": "1.0.0",
     "orientation": "portrait",
     "primaryColor": "#cccccc",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "dependencies": {
     "@expo/samples": "^2.0.2",
     "axios": "^0.16.2",
-    "expo": "^20.0.0",
+    "expo": "^21.0.0",
     "react": "16.0.0-alpha.12",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-20.0.0.tar.gz",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-21.0.2.tar.gz",
     "react-native-button": "^2.1.0",
     "react-native-modalbox": "^1.4.2",
     "react-navigation": "^1.0.0-beta.12"
   },
   "devDependencies": {
-    "jest-expo": "^20.0.0"
+    "jest-expo": "^21.0.0"
   }
 }


### PR DESCRIPTION
https://blog.expo.io/expo-sdk-21-0-0-is-now-available-be33b79921b7

Upgrading Your App
Here’s how to upgrade your app to Expo SDK 21.0.0 from 20.0.0:
Close XDE or your exp CLI server
In app.json, change sdkVersion to "21.0.0"
In package.json, change these dependencies:
- react-native to "https://github.com/expo/react-native/archive/sdk-21.0.2.tar.gz"
- expo to "^21.0.0"
- react did not change from SDK 20("16.0.0-alpha.12")
- jest-expo to "^21.0.0" (if you use it)
- sentry-expo did not change from SDK 20("~1.6.0")
Delete your project’s node_modules directory and run npm installagain (or use yarn, we love yarn)
Reopen your project in XDE and press “Restart” to clear the packager cache, or run exp start -c if you use use exp.
Update the Expo app on your phones from the App Store / Play Store. XDE and exp will automatically update your apps in simulators.